### PR TITLE
Fix building with GCC 10

### DIFF
--- a/sdk/src/rplidar_driver.cpp
+++ b/sdk/src/rplidar_driver.cpp
@@ -1821,7 +1821,7 @@ u_result RPlidarDriverImplCommon::grabScanData(rplidar_response_measurement_node
 {
     DEPRECATED_WARN("grabScanData()", "grabScanDataHq()");
 
-    switch (_dataEvt.wait(timeout))
+    switch (static_cast<int>(_dataEvt.wait(timeout)))
     {
     case rp::hal::Event::EVENT_TIMEOUT:
         count = 0;
@@ -1850,7 +1850,7 @@ u_result RPlidarDriverImplCommon::grabScanData(rplidar_response_measurement_node
 
 u_result RPlidarDriverImplCommon::grabScanDataHq(rplidar_response_measurement_node_hq_t * nodebuffer, size_t & count, _u32 timeout)
 {
-    switch (_dataEvt.wait(timeout))
+    switch (static_cast<int>(_dataEvt.wait(timeout)))
     {
     case rp::hal::Event::EVENT_TIMEOUT:
         count = 0;


### PR DESCRIPTION

Build failed due to narrowing from `long unsigned int` to `int`. 

Signed-off-by: Hunter L. Allen <hunter.allen@ghostrobotics.io>