### PR TITLE
Slam Toolbox compatibility

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -83,10 +83,10 @@ void publish_scan(std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::LaserScan>
       scan_msg.angle_max =  M_PI - angle_max;
     }
     scan_msg.angle_increment =
-        (scan_msg.angle_max - scan_msg.angle_min) / (double)(node_count-1);
+        (scan_msg.angle_max - scan_msg.angle_min) / (double)(node_count);
 
     scan_msg.scan_time = scan_time;
-    scan_msg.time_increment = scan_time / (double)(node_count-1);
+    scan_msg.time_increment = scan_time / (double)(node_count);
     scan_msg.range_min = 0.15;
     scan_msg.range_max = max_distance;//8.0;
 


### PR DESCRIPTION
As it is now. the RPLIDAR driver is not compatible with the latest version of Slam Toolbox.

This error will be received constantly instead: 
`LaserRangeScan contains 360 range readings, expected 359.`

Without this update, Slam Toolbox will not work with the RPLIDAR driver, however please let me know if you think there is a better solution.

The issue is explained here:
https://github.com/SteveMacenski/slam_toolbox/issues/278

The fix I propose forces the angle_increment to be calculated using all of the nodes, which prevents this error message from being displayed.
I also updated the scan_time to keep it in sync.