### PR TITLE
Adapte ros2 foxy launch file API to ros2 eloquent distro

### DIFF
--- a/launch/rplidar.launch.py
+++ b/launch/rplidar.launch.py
@@ -7,7 +7,7 @@ def generate_launch_description():
         Node(
             name='rplidar_composition',
             package='rplidar_ros',
-            executable='rplidar_composition',
+            node_executable='rplidar_composition',
             output='screen',
             parameters=[{
                 'serial_port': '/dev/ttyUSB0',

--- a/launch/view_rplidar.launch.py
+++ b/launch/view_rplidar.launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
         IncludeLaunchDescription(PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rplidar.launch.py'])),
         Node(
             package='rviz2',
-            executable='rviz2',
+            node_executable='rviz2',
             output='screen',
             arguments=['-d', [ThisLaunchFileDir(), '/../rviz/rplidar.rviz']],
         )

--- a/src/rplidar_node.cpp
+++ b/src/rplidar_node.cpp
@@ -82,10 +82,32 @@ rplidar_node::rplidar_node(const rclcpp::NodeOptions & options)
     }
   } else {
     // make connection...
-    if (IS_FAIL(m_drv->connect(serial_port_.c_str(), (_u32)serial_baudrate_))) {
+    uint32_t connect_status = m_drv->connect(serial_port_.c_str(), (_u32)serial_baudrate_);
+    if (IS_FAIL(connect_status)) {
       RCLCPP_ERROR(
         this->get_logger(), "Error, cannot bind to the specified serial port '%s'.",
         serial_port_.c_str());
+
+      std::string reason = "";
+
+      switch(connect_status) {
+	      case RESULT_ALREADY_DONE:
+		      reason = "ALREADY DONE";
+		      break;
+	      case RESULT_INSUFFICIENT_MEMORY:
+		      reason = "INSUFFICIENT MEMORY"; 
+		      break;
+	      case RESULT_INVALID_DATA:
+		      reason = "INVALID DATA";
+		      break;
+	      default:
+		      reason = "UNKNOWN";
+      }
+
+      RCLCPP_ERROR(
+        this->get_logger(), "Because '%s'.",
+        reason.c_str());
+
       RPlidarDriver::DisposeDriver(m_drv);
       return;
     }


### PR DESCRIPTION
This ros2 package assumes the ros2 distro is foxy by default, but in jetson nano board, the ros2 eloquent is installed. Eloquent use ~node_executable~ instead of ~executable~ in the init argument parameters, which causes an API misuse.